### PR TITLE
Implement Closer on Broker

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -118,3 +118,14 @@ func (b *Broker) Send(clientId string, event Event) error {
 func (b *Broker) SetDisconnectCallback(cb func(clientId string, sessionId string)) {
 	b.disconnectCallback = cb
 }
+
+//Close is used for cleanup operations in which we need to terminate a broker and close all client connections
+func (b *Broker) Close() error {
+	for _, v := range b.clientSessions {
+		for _, session := range v {
+			//Let's mark everything as completed
+			session.doneChan <- session
+		}
+	}
+	return nil
+}

--- a/broker.go
+++ b/broker.go
@@ -124,8 +124,11 @@ func (b *Broker) Close() error {
 	for _, v := range b.clientSessions {
 		for _, session := range v {
 			//Let's mark everything as completed
-			session.doneChan <- session
+			session.doneChan <- true
 		}
 	}
+
+	//Empty out client sessions
+	b.clientSessions = map[string]map[string]*ClientConnection{}
 	return nil
 }

--- a/broker.go
+++ b/broker.go
@@ -119,8 +119,10 @@ func (b *Broker) SetDisconnectCallback(cb func(clientId string, sessionId string
 	b.disconnectCallback = cb
 }
 
-//Close is used for cleanup operations in which we need to terminate a broker and close all client connections
+//Close is used for cleanup operations in which we need to terminate a broker and close all client connections.
+//this allows a subscription manager to handle the brokers without leaving orphaned references lying around.
 func (b *Broker) Close() error {
+	b.mtx.Lock()
 	for _, v := range b.clientSessions {
 		for _, session := range v {
 			//Let's mark everything as completed
@@ -130,5 +132,6 @@ func (b *Broker) Close() error {
 
 	//Empty out client sessions
 	b.clientSessions = map[string]map[string]*ClientConnection{}
+	b.mtx.Unlock()
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/subchord/go-sse
+module github.com/shairozan/go-sse
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/shairozan/go-sse
+module github.com/subchord/go-sse
 
 go 1.13
 


### PR DESCRIPTION
# Impetus
I'm writing an implementation using this library that actually wraps a subscription manager around Topics, each with their own broker to facilitate broadcast of messages to subscribers. The issue I ran into was a need to cleanup topics administratively and to close connections with remote clients. 

# Solution
I've implemented the `Closer` interface on the broker, and in doing so we iterate over all client connections, mark them as done, which triggers the closure of the connection

```go
package main

import (
	"errors"
	"fmt"
	"github.com/google/uuid"
	net "github.com/shairozan/go-sse"
	"log"
	"net/http"
	"strconv"
	"sync"
	"time"
)

var (
	ErrNoSuchTopic = errors.New("no topic with that name found")
)

type Topic struct {
	ID     string
	Broker *net.Broker
}

//Write is used to handle mass broadcast of log type data. Primarily used to couple to loggers
func (t Topic) Write(data []byte) (n int, err error){
	stringEvent := net.StringEvent{
		Id:    uuid.New().String(),
		Event: "log",
		Data:  string(data),
	}

	t.Broker.Broadcast(stringEvent)

	return len(data), nil
}

type SubscriptionManager struct {
	topics []*Topic
	mu     *sync.Mutex
	logger log.Logger
}

func (s *SubscriptionManager) GetTopics() []*Topic {
	return s.topics
}

func (s *SubscriptionManager) GetTopic(topic_id string) (*Topic, error){
	for _, v := range s.topics {
		if v.ID == topic_id {
			return v, nil
		}
	}

	return &Topic{}, ErrNoSuchTopic
}

func (s *SubscriptionManager) CreateTopic(topic_id string) *Topic {
	t := &Topic{
		ID:     topic_id,
		Broker: net.NewBroker(map[string]string{
			"Access-Control-Allow-Origin": "*",
		}),
	}

	s.mu.Lock()
	s.topics = append(s.topics,t)
	s.mu.Unlock()

	return t
}

func (s *SubscriptionManager) DeleteTopic(topic_id string) error {
	topic, err := s.GetTopic(topic_id)

	//If we can't find one, let's return the error
	if err != nil {
		return err
	}

	//Empty out the Broker
	topic.Broker.Close()
	topic.Broker = nil


	var targetKey int
	located := false

	for k, v := range s.topics {
		if v.ID == topic.ID {
			located = true
			targetKey = k
		}
	}

	if located {
		s.mu.Lock()

		//Copy last element to target key
		s.topics[targetKey] = s.topics[len(s.topics) - 1]

		//Erase last element
		s.topics[len(s.topics) - 1] = nil

		//Truncate
		s.topics = s.topics[:len(s.topics) - 1]

		s.mu.Unlock()
	}

	return nil
}

func main(){
	sm := SubscriptionManager{
		topics:   []*Topic{},
		mu:     &sync.Mutex{},
		logger: log.Logger{},
	}

	sm.CreateTopic("test")

	http.HandleFunc("/sse",sm.sseHandler)

	go func() {
		count := 0
		tick := time.Tick(5 * time.Second)
		for {
			select {
			case <-tick:
				count++
				topic, err := sm.GetTopic("test")

				if err == nil {
					topic.Broker.Broadcast(net.StringEvent{
						Id:    fmt.Sprintf("event-id-%v", count),
						Event: "update",
						Data:  fmt.Sprintf("Update to topic %s with data of %s",topic.ID,strconv.Itoa(count)),
					})
				}
			}
		}
	}()

	go func(){
		time.Sleep(15 *time.Second)
		sm.DeleteTopic("test")
	}()

	log.Fatal(http.ListenAndServe(":8080", http.DefaultServeMux))
}


func (sm SubscriptionManager) sseHandler(writer http.ResponseWriter, r *http.Request) {
	topicKey := r.URL.Query().Get("topic")
	topic, err  := sm.GetTopic(topicKey)

	if err != nil {
		writer.WriteHeader(404)
		return
	}


	client, err := topic.Broker.Connect(fmt.Sprintf("%v", time.Now().Unix()), writer, r)
	if err != nil {
		log.Println(err)
		return
	}
	<-client.Done()

	log.Printf("connection with client %v closed", client.Id())
}

```

The above code is the implementation I've been working with, and once the `DeleteTopic` method is called, it calls `Close` on the broker and I can see attached clients get disconnected. We also cleanup the map of clients / sessions to avoid anything else using it. 