### PR TITLE
adding StreamingUnsupportedError and UnknownClientError

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -1,7 +1,6 @@
 package net
 
 import (
-	"errors"
 	"net/http"
 	"sync"
 )
@@ -26,7 +25,9 @@ func (b *Broker) Connect(clientId string, w http.ResponseWriter, r *http.Request
 	client, err := newClientConnection(clientId, w, r)
 	if err != nil {
 		http.Error(w, "Streaming unsupported!", http.StatusInternalServerError)
-		return nil, errors.New("streaming unsupported")
+		streamingUnsupportedError := StreamingUnsupportedError
+		streamingUnsupportedError.Detail = err
+		return nil, streamingUnsupportedError
 	}
 
 	b.setHeaders(w)
@@ -107,7 +108,9 @@ func (b *Broker) Send(clientId string, event Event) error {
 	defer b.mtx.Unlock()
 	sessions, ok := b.clientSessions[clientId]
 	if !ok {
-		return errors.New("unknown client")
+		unknownClientError := UnknownClientError
+		unknownClientError.Detail = clientId
+		return unknownClientError
 	}
 	for _, c := range sessions {
 		c.Send(event)

--- a/client_connection.go
+++ b/client_connection.go
@@ -1,7 +1,6 @@
 package net
 
 import (
-	"errors"
 	"github.com/google/uuid"
 	"net/http"
 	"time"
@@ -24,7 +23,9 @@ func newClientConnection(id string, w http.ResponseWriter, r *http.Request) (*Cl
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		http.Error(w, "Streaming unsupported!", http.StatusInternalServerError)
-		return nil, errors.New("streaming unsupported")
+		streamingUnsupportedError := StreamingUnsupportedError
+		streamingUnsupportedError.Detail = "ResponseWriter(wrapper) does not support http.Flusher"
+		return nil, streamingUnsupportedError
 	}
 
 	return &ClientConnection{

--- a/error.go
+++ b/error.go
@@ -1,0 +1,22 @@
+package net
+
+import (
+	"fmt"
+)
+
+type Error struct {
+	Code    int
+	Message string
+	Detail  interface{}
+}
+
+var StreamingUnsupportedError = New(1, "streaming unsupported", nil)
+var UnknownClientError = New(2, "unknown client", nil)
+
+func New(code int, message string, detail interface{}) Error {
+	return Error{Code: code, Message: message, Detail: detail}
+}
+
+func (e Error) Error() string {
+	return fmt.Sprintf(e.Message)
+}


### PR DESCRIPTION
Adding specific error types with error codes and additional detail.
This way you can do error type or code checking to see what went wrong.

The error messages have not been altered for backwards compatibility reasons (Error type checking by string comparison)