### PR TITLE
Added support for json payloads in the data section of an event

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ if err != nil {
 	return
 }
 ```
-2. Subscribe to a specific type of event.
+2. Subscribe to a specific type of event. (passing "" instead of "message" will consume all topics)
 ```Go
 sub, err := feed.Subscribe("message")
 if err != nil {


### PR DESCRIPTION
Because of the split on : json payloads were getting mangled. I've replaced this with a regexp based process that, while less performant, should preserve any data sent in the format it was sent in.

I also added a feature to pass "" as the subscription.eventType to allow any event. I thought about using the string "all", but that could cause problems if users have an "all" event type if it really doesn't include all messages.