### PR TITLE
check for response code in ConnectWithSSEFeed

### DIFF
--- a/sse_feed.go
+++ b/sse_feed.go
@@ -63,6 +63,10 @@ func ConnectWithSSEFeed(url string, headers map[string][]string) (*SSEFeed, erro
 		return nil, err
 	}
 
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("expected status code %d, got %d", http.StatusOK, resp.StatusCode)
+	}
+
 	reader := bufio.NewReader(resp.Body)
 
 	feed := &SSEFeed{


### PR DESCRIPTION
when we call function `ConnectWithSSEFeed`, we are not checking for response code. I assumed its not intentional and therefore this PR. 

I am not 100% sure if we should just check for just `status code 200` or for `range 200-299`.

Kindly let me know your thoughts about this fix. 

