### PR TITLE
return error and dont close closed feed

### DIFF
--- a/sse_feed.go
+++ b/sse_feed.go
@@ -3,12 +3,13 @@ package net
 import (
 	"bufio"
 	"fmt"
-	"github.com/google/uuid"
 	"io"
 	"net/http"
 	neturl "net/url"
 	"strings"
 	"sync"
+
+	"github.com/google/uuid"
 )
 
 type Subscription struct {
@@ -79,14 +80,15 @@ func ConnectWithSSEFeed(url string, headers map[string][]string) (*SSEFeed, erro
 				break loop
 			default:
 				b, err := reader.ReadBytes('\n')
-				if len(b) == 0 {
-					continue
-				}
-
 				if err != nil && err != io.EOF {
 					feed.error(err)
 					return
 				}
+
+				if len(b) == 0 {
+					continue
+				}
+
 				feed.processRaw(b)
 			}
 		}
@@ -96,6 +98,10 @@ func ConnectWithSSEFeed(url string, headers map[string][]string) (*SSEFeed, erro
 }
 
 func (s *SSEFeed) Close() {
+	if s.closed {
+		return
+	}
+
 	close(s.stopChan)
 	for subId, _ := range s.subscriptions {
 		s.closeSubscription(subId)


### PR DESCRIPTION
- when an error occurs from the server side, we run into an infinite loop that causes cpu spike. we should check for error before checking for length of bytes read. 
- when the client (our code) tries to close the feed, it works ok. but in case of error, when sse_feed.go calls `feed.error(err)`, it already closes the channel and now our code panics because channel is already closed. I have added code to sse_feed to just return if channel is already closed instead of panicking. I had to do this inside sse_feed because that field is not exported.


kindly let me know if these changes makes sense and if i can provide more info about this.