### PR TITLE
Close c.msg channel

### DIFF
--- a/client_connection.go
+++ b/client_connection.go
@@ -60,6 +60,7 @@ writeLoop:
 	for {
 		select {
 		case <-c.request.Context().Done():
+			close(c.msg)
 			break writeLoop
 		case <-heartBeat.C:
 			go c.Send(HeartbeatEvent{})


### PR DESCRIPTION
c.msg channel should be closed when Broker is closing in order to prevent panic (race condition):

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x10d84b6]

goroutine 21 [running]:
bufio.(*Writer).Flush(0xc0000920c0)
	/usr/local/go/src/bufio/bufio.go:628 +0x56
net/http.(*response).Flush(0xc0000a2000)
	/usr/local/go/src/net/http/server.go:1681 +0x3a
github.com/subchord/go-sse.(*ClientConnection).serve(0xc0000940c0, 0x0?, 0xc00009a0c0)
	/Users/user/go/pkg/mod/github.com/subchord/go-sse@v1.0.7/client_connection.go:83 +0x1c6
created by github.com/subchord/go-sse.(*Broker).ConnectWithHeartBeatInterval
	/Users/user/go/pkg/mod/github.com/subchord/go-sse@v1.0.7/broker.go:42 +0x218
exit status 2